### PR TITLE
Fix with-current-buffer call

### DIFF
--- a/ox-jekyll-subtree.el
+++ b/ox-jekyll-subtree.el
@@ -122,8 +122,8 @@ will be a sanitised version of the title, see
            header-content subtree-content reference-buffer)
 
           ;; Export and then do some fixing on the output buffer.
-          (with-current-buffer
-              (org-jekyll-export-as-html nil t nil nil nil)
+          (org-jekyll-export-as-html nil t nil nil nil)
+          (with-current-buffer "*Org Jekyll HTML Export*"
             (goto-char (point-min))
             ;; Configure the jekyll header.
             (search-forward "\n---\n")


### PR DESCRIPTION
`with-current-buffer' takes as its first argument the buffer, but
org-jekyll-export-as-html does not return a buffer

This allows ox-jekyll-subtree to work with upstream org-octopress.

See also https://github.com/yoshinari-nomura/org-octopress/pull/19
