### PR TITLE
Modified date formatting such that jekyll front matter gets the h:m:s…

### DIFF
--- a/ox-jekyll-subtree.el
+++ b/ox-jekyll-subtree.el
@@ -80,8 +80,12 @@ will be a sanitised version of the title, see
       (outline-up-heading 1 t))
     (org-entry-put (point) "EXPORT_JEKYLL_LAYOUT"
                    (org-entry-get (point) "EXPORT_JEKYLL_LAYOUT" t))
-
-    (let* ((date (org-get-scheduled-time (point) nil))
+    ;; Try the closed stamp first to make sure we don't set the front
+    ;; matter to 00:00:00 which moves the post back a day
+    (let* ((closed-stamp (org-entry-get (point) "CLOSED" t))
+           (date (if closed-stamp
+                     (date-to-time closed-stamp)
+                     (org-get-scheduled-time (point) nil)))
            (tags (nreverse (org-get-tags-at)))
            (meta-title (org-entry-get (point) "meta_title"))
            (is-page (string= (org-entry-get (point) "EXPORT_JEKYLL_LAYOUT") "page"))

--- a/ox-jekyll-subtree.el
+++ b/ox-jekyll-subtree.el
@@ -103,10 +103,9 @@ will be a sanitised version of the title, see
               (error "Pages need a :filename: property"))
         ;; For posts, guess some information that wasn't provided as
         ;; properties.
-        (setq date (format-time-string "%Y-%m-%d" date))
         ;; Define a name, if there isn't one.
         (unless name
-          (setq name (concat date "-" (endless/sanitise-file-name title)))
+          (setq name (concat (format-time-string "%Y-%m-%d" date) "-" (endless/sanitise-file-name title)))
           (org-entry-put (point) "filename" name))
         (org-todo 'done))
 
@@ -137,7 +136,7 @@ will be a sanitised version of the title, see
             (if is-page
                 ;; Pages don't need a date field.
                 (replace-match "" :fixedcase :literal nil 0)
-              (replace-match (concat " " date) :fixedcase :literal nil 1))
+              (replace-match (concat " " (format-time-string "%Y-%m-%d %T" date)) :fixedcase :literal nil 1))
 
             ;; Save the final file.
             (endless/clean-output-links)


### PR DESCRIPTION
…format
which prevents strange action when posting multiple times a day.

Basically I had been posting multiple times and noticed my posts were out of order, 
I looked it up and jekyll accepts h:m:s in the front matter to differentiate posts on same day
