### PR TITLE
Update ox-jekyll-subtree with new API for org-next-link

### DIFF
--- a/ox-jekyll-subtree.el
+++ b/ox-jekyll-subtree.el
@@ -185,7 +185,7 @@ will be a sanitised version of the title, see
   (let ((this-filename (org-entry-get nil "filename" t))
         target-filename)
     (while (progn (org-next-link)
-                  (not org-link-search-failed))
+                  (not org-link--search-failed))
       (cond
        ((looking-at (format "\\[\\[\\(file:%s\\)"
                             (regexp-quote (abbreviate-file-name ojs-blog-dir))))


### PR DESCRIPTION
Tiny fix for running ox-jekyll-subtree under current emacs (28.0.50) and org-mode (9.4)